### PR TITLE
feat(testing): Add `Myprysm.AspNetCore.Testing` for easier API testing

### DIFF
--- a/MyprysmDotnetCommons.sln
+++ b/MyprysmDotnetCommons.sln
@@ -116,6 +116,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Myprysm.ImageService.Abstra
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Myprysm.PubSub.Abstractions.Testing", "src\abstractions\Myprysm.PubSub.Abstractions.Testing\Myprysm.PubSub.Abstractions.Testing.csproj", "{0BCC0834-0BA9-4577-8BFE-542AAA13AC8D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Myprysm.AspNetCore.Testing", "src\Myprysm.AspNetCore.Testing\Myprysm.AspNetCore.Testing.csproj", "{FB5005E7-06F2-483B-B85D-67239F240E3F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Myprysm.AspNetCore.Testing.Tests", "tests\Myprysm.AspNetCore.Testing.Tests\Myprysm.AspNetCore.Testing.Tests.csproj", "{3567CB15-DBAF-4068-A13E-6930D6EDAE48}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Myprysm.AspNetCore.Testing.TestApi", "tests\Myprysm.AspNetCore.Testing.TestApi\Myprysm.AspNetCore.Testing.TestApi.csproj", "{557EBC3B-CFB1-48B5-A0BC-1F8E74284B7F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -169,6 +175,9 @@ Global
 		{1479B592-9E22-41AD-BDD6-C04B25B996A5} = {341B3E44-33C5-4276-B199-8DEC935CB1A9}
 		{D5FA51AD-D8E4-408C-8F2E-0C6CAB768B54} = {341B3E44-33C5-4276-B199-8DEC935CB1A9}
 		{0BCC0834-0BA9-4577-8BFE-542AAA13AC8D} = {341B3E44-33C5-4276-B199-8DEC935CB1A9}
+		{FB5005E7-06F2-483B-B85D-67239F240E3F} = {16CD561D-0551-4688-8FEA-7368D8C6525E}
+		{3567CB15-DBAF-4068-A13E-6930D6EDAE48} = {F0B5D0F1-BBBD-4998-A008-8B7D758023CD}
+		{557EBC3B-CFB1-48B5-A0BC-1F8E74284B7F} = {F0B5D0F1-BBBD-4998-A008-8B7D758023CD}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DFA98688-E9E0-416B-A5EF-E53EAA379A5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -317,5 +326,17 @@ Global
 		{0BCC0834-0BA9-4577-8BFE-542AAA13AC8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0BCC0834-0BA9-4577-8BFE-542AAA13AC8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0BCC0834-0BA9-4577-8BFE-542AAA13AC8D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB5005E7-06F2-483B-B85D-67239F240E3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB5005E7-06F2-483B-B85D-67239F240E3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB5005E7-06F2-483B-B85D-67239F240E3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB5005E7-06F2-483B-B85D-67239F240E3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3567CB15-DBAF-4068-A13E-6930D6EDAE48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3567CB15-DBAF-4068-A13E-6930D6EDAE48}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3567CB15-DBAF-4068-A13E-6930D6EDAE48}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3567CB15-DBAF-4068-A13E-6930D6EDAE48}.Release|Any CPU.Build.0 = Release|Any CPU
+		{557EBC3B-CFB1-48B5-A0BC-1F8E74284B7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{557EBC3B-CFB1-48B5-A0BC-1F8E74284B7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{557EBC3B-CFB1-48B5-A0BC-1F8E74284B7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{557EBC3B-CFB1-48B5-A0BC-1F8E74284B7F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/Myprysm.AspNetCore.Testing/AuthenticatedWebApplicationFactory.cs
+++ b/src/Myprysm.AspNetCore.Testing/AuthenticatedWebApplicationFactory.cs
@@ -1,0 +1,29 @@
+﻿namespace Myprysm.AspNetCore.Testing;
+
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+/// <summary>
+/// An authenticated <see cref="WebApplicationFactory{TEntryPoint}"/> that configures the <see cref="MockJwtTokens"/> issuer for testing.
+/// </summary>
+/// <typeparam name="TStartup"></typeparam>
+public abstract class AuthenticatedWebApplicationFactory<TStartup> : WebApplicationFactory<TStartup>
+    where TStartup : class
+{
+    /// <inheritdoc />
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+        builder.ConfigureServices(services =>
+            services.Configure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme,
+                options =>
+                {
+                    var config = new OpenIdConnectConfiguration { Issuer = MockJwtTokens.Issuer };
+
+                    config.SigningKeys.Add(MockJwtTokens.SecurityKey);
+                    options.Configuration = config;
+                    options.TokenValidationParameters.ValidateAudience = false;
+                }));
+    }
+}

--- a/src/Myprysm.AspNetCore.Testing/IntegrationTests.cs
+++ b/src/Myprysm.AspNetCore.Testing/IntegrationTests.cs
@@ -1,0 +1,50 @@
+﻿namespace Myprysm.AspNetCore.Testing;
+
+using System.Reflection;
+using AutoFixture;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Myprysm.Testing.NUnit;
+using NUnit.Framework;
+
+/// <summary>
+/// Base integration test to remotely assert the behaviour of an API. 
+/// </summary>
+/// <typeparam name="TStartup">The entry point of the API under test.</typeparam>
+[Category(Categories.Integration)]
+public abstract class IntegrationTests<TStartup> : FixtureTests
+    where TStartup : class
+{
+    /// <summary>
+    /// The <see cref="HttpClient"/> configured to access the running API.
+    /// </summary>
+    protected HttpClient Client { get; private set; } = null!;
+
+    /// <summary>
+    /// The <see cref="IServiceProvider"/> of the running API.
+    /// </summary>
+    protected IServiceProvider Services { get; private set; } = null!;
+
+    /// <summary>
+    /// Configure the <see cref="Client"/> and <see cref="Services"/> for the current test suite.
+    /// </summary>
+    [OneTimeSetUp]
+    public void SetUpApi()
+    {
+        var factory = this.CreateFactory();
+        this.Client = factory.CreateClient();
+        this.Services = factory.Services;
+    }
+
+    /// <summary>
+    /// Factory method that should provide the <see cref="WebApplicationFactory{TEntryPoint}"/> for the API under test.
+    /// You can provide the same factory to multiple test suites.
+    /// </summary>
+    /// <returns>The factory for the API under test.</returns>
+    protected abstract WebApplicationFactory<TStartup> CreateFactory();
+
+    /// <inheritdoc />
+    protected override void CustomizeFixture(Fixture fixture)
+    {
+        fixture.LoadCustomizations(Assembly.GetExecutingAssembly());
+    }
+}

--- a/src/Myprysm.AspNetCore.Testing/MockJwtTokens.cs
+++ b/src/Myprysm.AspNetCore.Testing/MockJwtTokens.cs
@@ -1,0 +1,49 @@
+namespace Myprysm.AspNetCore.Testing;
+
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using Microsoft.IdentityModel.Tokens;
+
+/// <summary>
+/// Mock token issuer that can be used to generate JWTs for integration testing.
+/// </summary>
+public static class MockJwtTokens
+{
+    /// <summary>
+    /// The issuer name for the current test session.
+    /// </summary>
+    public static string Issuer { get; } = Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// The security key for the current session.
+    /// </summary>
+    public static SecurityKey SecurityKey { get; }
+
+    /// <summary>
+    /// The signing credentials for the current session.
+    /// </summary>
+    public static SigningCredentials SigningCredentials { get; }
+
+    private static readonly JwtSecurityTokenHandler TokenHandler = new();
+    private static readonly RandomNumberGenerator Rng = RandomNumberGenerator.Create();
+    private static readonly byte[] Key = new byte[32];
+
+    static MockJwtTokens()
+    {
+        Rng.GetBytes(Key);
+        SecurityKey = new SymmetricSecurityKey(Key) { KeyId = Guid.NewGuid().ToString(), };
+        SigningCredentials = new SigningCredentials(SecurityKey, SecurityAlgorithms.HmacSha256);
+    }
+
+    /// <summary>
+    /// Generate a JWT with the provided claims.
+    /// </summary>
+    /// <param name="claims">The claims to add in the JWT.</param>
+    /// <returns>The JWT with the claims, signed with </returns>
+    public static string GenerateJwtToken(params Claim[] claims)
+    {
+        return TokenHandler.WriteToken(new JwtSecurityToken(Issuer, null, claims, null, DateTime.UtcNow.AddMinutes(20), SigningCredentials));
+    }
+}

--- a/src/Myprysm.AspNetCore.Testing/Myprysm.AspNetCore.Testing.csproj
+++ b/src/Myprysm.AspNetCore.Testing/Myprysm.AspNetCore.Testing.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Library</OutputType>
+    <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <DefaultDocumentationGeneratedPages>Assembly, Types</DefaultDocumentationGeneratedPages>
+
+    <Description>Myprysm testing utilities for AspNetCore APIs.</Description>
+    <PackageTags>myprysm testing tests test nunit asp aspnetcore integration</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Myprysm.Testing.NUnit\Myprysm.Testing.NUnit.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Myprysm.AspNetCore.Testing/documentation/Myprysm_AspNetCore_Testing_AuthenticatedWebApplicationFactory_TStartup_.md
+++ b/src/Myprysm.AspNetCore.Testing/documentation/Myprysm_AspNetCore_Testing_AuthenticatedWebApplicationFactory_TStartup_.md
@@ -1,0 +1,14 @@
+#### [Myprysm.AspNetCore.Testing](index.md 'index')
+### [Myprysm.AspNetCore.Testing](index.md#Myprysm_AspNetCore_Testing 'Myprysm.AspNetCore.Testing')
+## AuthenticatedWebApplicationFactory&lt;TStartup&gt; Class
+An authenticated [Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory&lt;&gt;](https://docs.microsoft.com/en-us/dotnet/api/Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory-1 'Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1') that configures the [MockJwtTokens](Myprysm_AspNetCore_Testing_MockJwtTokens.md 'Myprysm.AspNetCore.Testing.MockJwtTokens') issuer for testing.  
+```csharp
+public abstract class AuthenticatedWebApplicationFactory<TStartup> : Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<TStartup>
+    where TStartup : class
+```
+#### Type parameters
+<a name='Myprysm_AspNetCore_Testing_AuthenticatedWebApplicationFactory_TStartup__TStartup'></a>
+`TStartup`  
+  
+
+Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object') &#129106; [Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory&lt;](https://docs.microsoft.com/en-us/dotnet/api/Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory-1 'Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1')[TStartup](Myprysm_AspNetCore_Testing_AuthenticatedWebApplicationFactory_TStartup_.md#Myprysm_AspNetCore_Testing_AuthenticatedWebApplicationFactory_TStartup__TStartup 'Myprysm.AspNetCore.Testing.AuthenticatedWebApplicationFactory&lt;TStartup&gt;.TStartup')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory-1 'Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1') &#129106; AuthenticatedWebApplicationFactory&lt;TStartup&gt;  

--- a/src/Myprysm.AspNetCore.Testing/documentation/Myprysm_AspNetCore_Testing_IntegrationTests_TStartup_.md
+++ b/src/Myprysm.AspNetCore.Testing/documentation/Myprysm_AspNetCore_Testing_IntegrationTests_TStartup_.md
@@ -1,0 +1,23 @@
+#### [Myprysm.AspNetCore.Testing](index.md 'index')
+### [Myprysm.AspNetCore.Testing](index.md#Myprysm_AspNetCore_Testing 'Myprysm.AspNetCore.Testing')
+## IntegrationTests&lt;TStartup&gt; Class
+Base integration test to remotely assert the behaviour of an API.   
+```csharp
+public abstract class IntegrationTests<TStartup> : Myprysm.Testing.NUnit.FixtureTests
+    where TStartup : class
+```
+#### Type parameters
+<a name='Myprysm_AspNetCore_Testing_IntegrationTests_TStartup__TStartup'></a>
+`TStartup`  
+The entry point of the API under test.
+  
+
+Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object') &#129106; [Myprysm.Testing.NUnit.FixtureTests](https://docs.microsoft.com/en-us/dotnet/api/Myprysm.Testing.NUnit.FixtureTests 'Myprysm.Testing.NUnit.FixtureTests') &#129106; IntegrationTests&lt;TStartup&gt;  
+### Methods
+<a name='Myprysm_AspNetCore_Testing_IntegrationTests_TStartup__SetUpApi()'></a>
+## IntegrationTests&lt;TStartup&gt;.SetUpApi() Method
+Configure the [Myprysm.AspNetCore.Testing.IntegrationTests&lt;&gt;.Client](https://docs.microsoft.com/en-us/dotnet/api/Myprysm.AspNetCore.Testing.IntegrationTests-1.Client 'Myprysm.AspNetCore.Testing.IntegrationTests`1.Client') and [Myprysm.AspNetCore.Testing.IntegrationTests&lt;&gt;.Services](https://docs.microsoft.com/en-us/dotnet/api/Myprysm.AspNetCore.Testing.IntegrationTests-1.Services 'Myprysm.AspNetCore.Testing.IntegrationTests`1.Services') for the current test suite.  
+```csharp
+public void SetUpApi();
+```
+  

--- a/src/Myprysm.AspNetCore.Testing/documentation/Myprysm_AspNetCore_Testing_MockJwtTokens.md
+++ b/src/Myprysm.AspNetCore.Testing/documentation/Myprysm_AspNetCore_Testing_MockJwtTokens.md
@@ -1,0 +1,53 @@
+#### [Myprysm.AspNetCore.Testing](index.md 'index')
+### [Myprysm.AspNetCore.Testing](index.md#Myprysm_AspNetCore_Testing 'Myprysm.AspNetCore.Testing')
+## MockJwtTokens Class
+Mock token issuer that can be used to generate JWTs for integration testing.  
+```csharp
+public static class MockJwtTokens
+```
+
+Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object') &#129106; MockJwtTokens  
+### Properties
+<a name='Myprysm_AspNetCore_Testing_MockJwtTokens_Issuer'></a>
+## MockJwtTokens.Issuer Property
+The issuer name for the current test session.  
+```csharp
+public static string Issuer { get; }
+```
+#### Property Value
+[System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')
+  
+<a name='Myprysm_AspNetCore_Testing_MockJwtTokens_SecurityKey'></a>
+## MockJwtTokens.SecurityKey Property
+The security key for the current session.  
+```csharp
+public static Microsoft.IdentityModel.Tokens.SecurityKey SecurityKey { get; }
+```
+#### Property Value
+[Microsoft.IdentityModel.Tokens.SecurityKey](https://docs.microsoft.com/en-us/dotnet/api/Microsoft.IdentityModel.Tokens.SecurityKey 'Microsoft.IdentityModel.Tokens.SecurityKey')
+  
+<a name='Myprysm_AspNetCore_Testing_MockJwtTokens_SigningCredentials'></a>
+## MockJwtTokens.SigningCredentials Property
+The signing credentials for the current session.  
+```csharp
+public static Microsoft.IdentityModel.Tokens.SigningCredentials SigningCredentials { get; }
+```
+#### Property Value
+[Microsoft.IdentityModel.Tokens.SigningCredentials](https://docs.microsoft.com/en-us/dotnet/api/Microsoft.IdentityModel.Tokens.SigningCredentials 'Microsoft.IdentityModel.Tokens.SigningCredentials')
+  
+### Methods
+<a name='Myprysm_AspNetCore_Testing_MockJwtTokens_GenerateJwtToken(System_Security_Claims_Claim__)'></a>
+## MockJwtTokens.GenerateJwtToken(Claim[]) Method
+Generate a JWT with the provided claims.  
+```csharp
+public static string GenerateJwtToken(params System.Security.Claims.Claim[] claims);
+```
+#### Parameters
+<a name='Myprysm_AspNetCore_Testing_MockJwtTokens_GenerateJwtToken(System_Security_Claims_Claim__)_claims'></a>
+`claims` [System.Security.Claims.Claim](https://docs.microsoft.com/en-us/dotnet/api/System.Security.Claims.Claim 'System.Security.Claims.Claim')[[]](https://docs.microsoft.com/en-us/dotnet/api/System.Array 'System.Array')  
+The claims to add in the JWT.
+  
+#### Returns
+[System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')  
+The JWT with the claims, signed with 
+  

--- a/src/Myprysm.AspNetCore.Testing/documentation/index.md
+++ b/src/Myprysm.AspNetCore.Testing/documentation/index.md
@@ -1,0 +1,11 @@
+#### [Myprysm.AspNetCore.Testing](index.md 'index')
+### Namespaces
+<a name='Myprysm_AspNetCore_Testing'></a>
+## Myprysm.AspNetCore.Testing Namespace
+
+| Classes | |
+| :--- | :--- |
+| [AuthenticatedWebApplicationFactory&lt;TStartup&gt;](Myprysm_AspNetCore_Testing_AuthenticatedWebApplicationFactory_TStartup_.md 'Myprysm.AspNetCore.Testing.AuthenticatedWebApplicationFactory&lt;TStartup&gt;') | An authenticated [Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory&lt;&gt;](https://docs.microsoft.com/en-us/dotnet/api/Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory-1 'Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1') that configures the [MockJwtTokens](Myprysm_AspNetCore_Testing_MockJwtTokens.md 'Myprysm.AspNetCore.Testing.MockJwtTokens') issuer for testing.<br/> |
+| [IntegrationTests&lt;TStartup&gt;](Myprysm_AspNetCore_Testing_IntegrationTests_TStartup_.md 'Myprysm.AspNetCore.Testing.IntegrationTests&lt;TStartup&gt;') | Base integration test to remotely assert the behaviour of an API. <br/> |
+| [MockJwtTokens](Myprysm_AspNetCore_Testing_MockJwtTokens.md 'Myprysm.AspNetCore.Testing.MockJwtTokens') | Mock token issuer that can be used to generate JWTs for integration testing.<br/> |
+  

--- a/tests/Myprysm.AspNetCore.Testing.TestApi/Controllers/AnonymousController.cs
+++ b/tests/Myprysm.AspNetCore.Testing.TestApi/Controllers/AnonymousController.cs
@@ -1,0 +1,14 @@
+namespace Myprysm.AspNetCore.Testing.Tests;
+
+using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("anonymous")]
+public class AnonymousController : ControllerBase
+{
+    [HttpGet("")]
+    public IActionResult GetAnonymousResource()
+    {
+        return this.Ok(new Response(3));
+    }
+}

--- a/tests/Myprysm.AspNetCore.Testing.TestApi/Controllers/AuthenticatedController.cs
+++ b/tests/Myprysm.AspNetCore.Testing.TestApi/Controllers/AuthenticatedController.cs
@@ -1,0 +1,23 @@
+﻿namespace Myprysm.AspNetCore.Testing.Tests;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+[Authorize]
+[ApiController]
+[Route("authorized")]
+public class AuthenticatedController : ControllerBase
+{
+    [HttpGet("")]
+    public IActionResult GetDefaultAuthorizedResource()
+    {
+        return this.Ok(new Response(42));
+    }
+    
+    [Authorize("custom-policy")]
+    [HttpGet("scoped")]
+    public IActionResult GetScopeAuthorizedResource()
+    {
+        return this.Ok(new Response(69));
+    }
+}

--- a/tests/Myprysm.AspNetCore.Testing.TestApi/Myprysm.AspNetCore.Testing.TestApi.csproj
+++ b/tests/Myprysm.AspNetCore.Testing.TestApi/Myprysm.AspNetCore.Testing.TestApi.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsCodeSharingProject>true</IsCodeSharingProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Remove="appsettings.Development.json" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Myprysm.AspNetCore.Testing.TestApi/Program.cs
+++ b/tests/Myprysm.AspNetCore.Testing.TestApi/Program.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Myprysm.AspNetCore.Testing.Tests;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services
+    .AddSingleton(new Response(1))
+    .AddControllers();
+
+
+builder.Services
+    .AddAuthorization(options =>
+    {
+        options.DefaultPolicy = new AuthorizationPolicyBuilder(JwtBearerDefaults.AuthenticationScheme)
+            .RequireAuthenticatedUser()
+            .Build();
+
+
+        options.AddPolicy(
+            "custom-policy",
+            b => b.RequireClaim("scope", "custom:claim"));
+    })
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer();
+
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();
+
+public partial class Program
+{
+}

--- a/tests/Myprysm.AspNetCore.Testing.TestApi/Response.cs
+++ b/tests/Myprysm.AspNetCore.Testing.TestApi/Response.cs
@@ -1,0 +1,3 @@
+﻿namespace Myprysm.AspNetCore.Testing.Tests;
+
+public record Response(int Answer);

--- a/tests/Myprysm.AspNetCore.Testing.TestApi/appsettings.json
+++ b/tests/Myprysm.AspNetCore.Testing.TestApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/tests/Myprysm.AspNetCore.Testing.Tests/Integration/IntegrationTestsTests.cs
+++ b/tests/Myprysm.AspNetCore.Testing.Tests/Integration/IntegrationTestsTests.cs
@@ -1,0 +1,25 @@
+﻿namespace Myprysm.AspNetCore.Testing.Tests.Integration;
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+[TestFixture]
+public class IntegrationTestsTests : IntegrationTests<Program>
+{
+    protected override WebApplicationFactory<Program> CreateFactory()
+    {
+        return TestApiSetup.Factory;
+    }
+
+    [Test]
+    public void Services_ProvideApiServices()
+    {
+        // Arrange + Act
+        var response = this.Services.GetRequiredService<Response>();
+        
+        // Assert
+        response.Answer.Should().Be(1);
+    }
+}

--- a/tests/Myprysm.AspNetCore.Testing.Tests/Integration/TestApiSetup.cs
+++ b/tests/Myprysm.AspNetCore.Testing.Tests/Integration/TestApiSetup.cs
@@ -1,0 +1,22 @@
+﻿namespace Myprysm.AspNetCore.Testing.Tests.Integration;
+
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+[SetUpFixture]
+public class TestApiSetup
+{
+    public static TestFactory Factory { get; private set; } = null!;
+
+    [OneTimeSetUp]
+    public void CreateApi()
+    {
+        Factory = new TestFactory();
+    }
+
+    [OneTimeTearDown]
+    public async Task TearDownApi()
+    {
+        await Factory.DisposeAsync();
+    }
+}

--- a/tests/Myprysm.AspNetCore.Testing.Tests/Integration/TestFactory.cs
+++ b/tests/Myprysm.AspNetCore.Testing.Tests/Integration/TestFactory.cs
@@ -1,0 +1,6 @@
+﻿namespace Myprysm.AspNetCore.Testing.Tests.Integration;
+
+public class TestFactory : AuthenticatedWebApplicationFactory<Program>
+{
+    
+}

--- a/tests/Myprysm.AspNetCore.Testing.Tests/Integration/TokenFactoryTests.cs
+++ b/tests/Myprysm.AspNetCore.Testing.Tests/Integration/TokenFactoryTests.cs
@@ -1,0 +1,134 @@
+﻿namespace Myprysm.AspNetCore.Testing.Tests.Integration;
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using NUnit.Framework;
+
+[TestFixture]
+public class TokenFactoryTests : IntegrationTests<Program>
+{
+    protected override WebApplicationFactory<Program> CreateFactory()
+    {
+        return TestApiSetup.Factory;
+    }
+
+    [Test]
+    public async Task GenerateToken_TokenWithoutScope_ShouldAuthenticateDefaultResource()
+    {
+        // Arrange
+        var token = MockJwtTokens.GenerateJwtToken(new Claim("sub", "A user"));
+        this.Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        // Act
+        var response = await this.Client.GetAsync("authorized");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadFromJsonAsync<Response>();
+
+        content.Should().NotBeNull();
+        content!.Answer.Should().Be(42);
+    }
+
+    [Test]
+    public async Task GenerateToken_TokenWithoutScope_ShouldAuthenticateAnonymousResource()
+    {
+        // Arrange
+        var token = MockJwtTokens.GenerateJwtToken(new Claim("sub", "A user"));
+        this.Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        // Act
+        var response = await this.Client.GetAsync("anonymous");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadFromJsonAsync<Response>();
+
+        content.Should().NotBeNull();
+        content!.Answer.Should().Be(3);
+    }
+
+    [Test]
+    public async Task GenerateToken_TokenWithoutScope_ShouldRejectScopedResource()
+    {
+        // Arrange
+        var token = MockJwtTokens.GenerateJwtToken(new Claim("sub", "A user"));
+        this.Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        // Act
+        var response = await this.Client.GetAsync("authorized/scoped");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Test]
+    public async Task GenerateToken_TokenWithScope_ShouldAuthenticateDefaultResource()
+    {
+        // Arrange
+        var token = MockJwtTokens.GenerateJwtToken(
+            new Claim("sub", "A user"),
+            new Claim("scope", "custom:claim"));
+        this.Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        // Act
+        var response = await this.Client.GetAsync("authorized");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadFromJsonAsync<Response>();
+
+        content.Should().NotBeNull();
+        content!.Answer.Should().Be(42);
+    }
+
+    [Test]
+    public async Task GenerateToken_TokenWithScope_ShouldAuthenticateScopedResource()
+    {
+        // Arrange
+        var token = MockJwtTokens.GenerateJwtToken(
+            new Claim("sub", "A user"),
+            new Claim("scope", "custom:claim"));
+        this.Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        // Act
+        var response = await this.Client.GetAsync("authorized/scoped");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadFromJsonAsync<Response>();
+
+        content.Should().NotBeNull();
+        content!.Answer.Should().Be(69);
+    }
+
+    [Test]
+    public async Task GenerateToken_TokenWithScope_ShouldAuthenticateAnonymousResource()
+    {
+        // Arrange
+        var token = MockJwtTokens.GenerateJwtToken(
+            new Claim("sub", "A user"),
+            new Claim("scope", "custom:claim"));
+        this.Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        // Act
+        var response = await this.Client.GetAsync("anonymous");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadFromJsonAsync<Response>();
+
+        content.Should().NotBeNull();
+        content!.Answer.Should().Be(3);
+    }
+}

--- a/tests/Myprysm.AspNetCore.Testing.Tests/Myprysm.AspNetCore.Testing.Tests.csproj
+++ b/tests/Myprysm.AspNetCore.Testing.Tests/Myprysm.AspNetCore.Testing.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Myprysm.AspNetCore.Testing\Myprysm.AspNetCore.Testing.csproj" />
+    <ProjectReference Include="..\Myprysm.AspNetCore.Testing.TestApi\Myprysm.AspNetCore.Testing.TestApi.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Provide a `MockJwtTokens` factory that can be used in combination with the `AuthenticatedWebApplicationFactory` to test different authorization claims.

Provide an `IntegrationTests` base suite that can be used to access an API by providing a `WebApplicationFactory` and receiving the associated `HttpClient` and `IServiceProvider`