### PR TITLE
fix(kernel)!: Remove optional constraint on IReader

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,23 +3,19 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AutoFixture" Version="4.17.0" />
-    <PackageVersion Include="AutoFixture.SeedExtensions" Version="4.17.0" />
-
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.14.1" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.12.0" />
-
-    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
-
+    <PackageVersion Include="AutoFixture" Version="4.18.0" />
+    <PackageVersion Include="AutoFixture.SeedExtensions" Version="4.18.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.16.0" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.14.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
     <PackageVersion Include="DefaultDocumentation" Version="0.8.3-beta1" />
-
-    <PackageVersion Include="FluentAssertions" Version="6.8.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.11.0" />
     <PackageVersion Include="FluentAssertions.Json" Version="6.1.0" />
-
     <PackageVersion Include="GitVersion.Tool" Version="[5.8.1]" />
-
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
@@ -29,43 +25,30 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-
-    <PackageVersion Include="Minio" Version="4.0.6" />
-
+    <PackageVersion Include="Minio" Version="5.0.0" />
     <PackageVersion Include="Moq" Version="4.18.2" />
-
-    <PackageVersion Include="NATS.Client" Version="1.0.2" />
-
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
-
-    <PackageVersion Include="NodaTime" Version="3.1.6" />
-
+    <PackageVersion Include="NATS.Client" Version="1.0.6" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="NodaTime" Version="3.1.9" />
     <PackageVersion Include="Nuke.Common" Version="6.2.1" />
-
     <PackageVersion Include="nunit" Version="3.13.3" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.3.1" />
-
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.9" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.4.0-beta.3" />
-
-    <PackageVersion Include="Polly" Version="7.2.3" />
-
-    <PackageVersion Include="SixLabors.ImageSharp" Version="2.1.3" />
-
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
+    <PackageVersion Include="Polly" Version="7.2.4" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="2.1.4" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.19" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.19" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.8" />
   </ItemGroup>
 </Project>

--- a/src/Myprysm.SharedKernel/Interfaces/IReader.cs
+++ b/src/Myprysm.SharedKernel/Interfaces/IReader.cs
@@ -22,5 +22,5 @@ public interface IReader<in TRequest, TResponse>
     /// <param name="request">The request.</param>
     /// <param name="cancellation">The cancellation token.</param>
     /// <returns>The output corresponding to the request.</returns>
-    Task<TResponse?> ReadAsync(TRequest request, CancellationToken cancellation = default);
+    Task<TResponse> ReadAsync(TRequest request, CancellationToken cancellation = default);
 }

--- a/src/Myprysm.SharedKernel/documentation/Myprysm.SharedKernel.Interfaces.IReader_TRequest,TResponse_.md
+++ b/src/Myprysm.SharedKernel/documentation/Myprysm.SharedKernel.Interfaces.IReader_TRequest,TResponse_.md
@@ -31,7 +31,7 @@ The response type.
 Read asynchronously the output for the given request.
 
 ```csharp
-System.Threading.Tasks.Task<TResponse?> ReadAsync(TRequest request, System.Threading.CancellationToken cancellation=default(System.Threading.CancellationToken));
+System.Threading.Tasks.Task<TResponse> ReadAsync(TRequest request, System.Threading.CancellationToken cancellation=default(System.Threading.CancellationToken));
 ```
 #### Parameters
 


### PR DESCRIPTION
BREAKING CHANGE: IReader implementations must explicitly expose whether the result can be null. It means that any code using nullable reference type may break because the reader interface doesn't declare anymore that the result may be null