### PR TITLE
feat(kernel)!: Enforce IExecutionResult on IWriter

### DIFF
--- a/build/Configuration.cs
+++ b/build/Configuration.cs
@@ -6,8 +6,8 @@ using Nuke.Common.Tooling;
 [TypeConverter(typeof(TypeConverter<Configuration>))]
 public class Configuration : Enumeration
 {
-    public static Configuration Debug = new Configuration { Value = nameof(Debug) };
-    public static Configuration Release = new Configuration { Value = nameof(Release) };
+    public static Configuration Debug = new() { Value = nameof(Debug) };
+    public static Configuration Release = new() { Value = nameof(Release) };
 
     public static implicit operator string(Configuration configuration)
     {

--- a/src/Myprysm.SharedKernel/ExecutionResults/ExecutionResult.cs
+++ b/src/Myprysm.SharedKernel/ExecutionResults/ExecutionResult.cs
@@ -29,10 +29,10 @@ namespace Myprysm.SharedKernel.ExecutionResults;
 public abstract class ExecutionResult : IExecutionResult
 {
     private static readonly IExecutionResult SuccessResult = new SuccessExecutionResult();
-    private static readonly IExecutionResult FailedResult = new FailedExecutionResult(Enumerable.Empty<string>());
-    private static readonly IExecutionResult NotFoundResult = new NotFoundExecutionResult(Enumerable.Empty<string>());
-    private static readonly IExecutionResult ForbiddenResult = new ForbiddenExecutionResult(Enumerable.Empty<string>());
-    private static readonly IExecutionResult ConflictResult = new ConflictExecutionResult(Enumerable.Empty<string>());
+    private static readonly FailedExecutionResult FailedResult = new(Enumerable.Empty<string>());
+    private static readonly NotFoundExecutionResult NotFoundResult = new(Enumerable.Empty<string>());
+    private static readonly ForbiddenExecutionResult ForbiddenResult = new(Enumerable.Empty<string>());
+    private static readonly ConflictExecutionResult ConflictResult = new(Enumerable.Empty<string>());
 
     internal ExecutionResult()
     {
@@ -65,7 +65,7 @@ public abstract class ExecutionResult : IExecutionResult
     /// Returns a failed execution result.
     /// </summary>
     /// <returns>The failed execution result.</returns>
-    public static IExecutionResult Failed()
+    public static FailedExecutionResult Failed()
     {
         return FailedResult;
     }
@@ -75,7 +75,7 @@ public abstract class ExecutionResult : IExecutionResult
     /// </summary>
     /// <param name="errors">The errors to report.</param>
     /// <returns>A failed execution result containing the provided errors as a reason.</returns>
-    public static IExecutionResult Failed(IEnumerable<string> errors)
+    public static FailedExecutionResult Failed(IEnumerable<string> errors)
     {
         return new FailedExecutionResult(errors);
     }
@@ -85,7 +85,7 @@ public abstract class ExecutionResult : IExecutionResult
     /// </summary>
     /// <param name="errors">The errors to report.</param>
     /// <returns>A failed execution result containing the provided errors as a reason.</returns>
-    public static IExecutionResult Failed(params string[] errors)
+    public static FailedExecutionResult Failed(params string[] errors)
     {
         return Failed((IEnumerable<string>)errors);
     }
@@ -94,7 +94,7 @@ public abstract class ExecutionResult : IExecutionResult
     /// Returns a not found execution result.
     /// </summary>
     /// <returns>The not found execution result.</returns>
-    public static IExecutionResult NotFound()
+    public static NotFoundExecutionResult NotFound()
     {
         return NotFoundResult;
     }
@@ -104,7 +104,7 @@ public abstract class ExecutionResult : IExecutionResult
     /// </summary>
     /// <param name="errors">The errors to report.</param>
     /// <returns>A not found execution result containing the provided errors as a reason.</returns>
-    public static IExecutionResult NotFound(IEnumerable<string> errors)
+    public static NotFoundExecutionResult NotFound(IEnumerable<string> errors)
     {
         return new NotFoundExecutionResult(errors);
     }
@@ -114,7 +114,7 @@ public abstract class ExecutionResult : IExecutionResult
     /// </summary>
     /// <param name="errors">The errors to report.</param>
     /// <returns>A not found execution result containing the provided errors as a reason.</returns>
-    public static IExecutionResult NotFound(params string[] errors)
+    public static NotFoundExecutionResult NotFound(params string[] errors)
     {
         return NotFound((IEnumerable<string>)errors);
     }
@@ -123,7 +123,7 @@ public abstract class ExecutionResult : IExecutionResult
     /// Returns a forbidden execution result.
     /// </summary>
     /// <returns>The forbidden execution result.</returns>
-    public static IExecutionResult Forbidden()
+    public static ForbiddenExecutionResult Forbidden()
     {
         return ForbiddenResult;
     }
@@ -133,7 +133,7 @@ public abstract class ExecutionResult : IExecutionResult
     /// </summary>
     /// <param name="errors">The errors to report.</param>
     /// <returns>A forbidden execution result containing the provided errors as a reason.</returns>
-    public static IExecutionResult Forbidden(IEnumerable<string> errors)
+    public static ForbiddenExecutionResult Forbidden(IEnumerable<string> errors)
     {
         return new ForbiddenExecutionResult(errors);
     }
@@ -143,7 +143,7 @@ public abstract class ExecutionResult : IExecutionResult
     /// </summary>
     /// <param name="errors">The errors to report.</param>
     /// <returns>A forbidden execution result containing the provided errors as a reason.</returns>
-    public static IExecutionResult Forbidden(params string[] errors)
+    public static ForbiddenExecutionResult Forbidden(params string[] errors)
     {
         return Forbidden((IEnumerable<string>)errors);
     }
@@ -152,7 +152,7 @@ public abstract class ExecutionResult : IExecutionResult
     /// Returns a conflict execution result.
     /// </summary>
     /// <returns>The conflict execution result.</returns>
-    public static IExecutionResult Conflict()
+    public static ConflictExecutionResult Conflict()
     {
         return ConflictResult;
     }
@@ -162,7 +162,7 @@ public abstract class ExecutionResult : IExecutionResult
     /// </summary>
     /// <param name="errors">The errors to report.</param>
     /// <returns>A conflict execution result containing the provided errors as a reason.</returns>
-    public static IExecutionResult Conflict(IEnumerable<string> errors)
+    public static ConflictExecutionResult Conflict(IEnumerable<string> errors)
     {
         return new ConflictExecutionResult(errors);
     }
@@ -172,7 +172,7 @@ public abstract class ExecutionResult : IExecutionResult
     /// </summary>
     /// <param name="errors">The errors to report.</param>
     /// <returns>A conflict execution result containing the provided errors as a reason.</returns>
-    public static IExecutionResult Conflict(params string[] errors)
+    public static ConflictExecutionResult Conflict(params string[] errors)
     {
         return Conflict((IEnumerable<string>)errors);
     }

--- a/src/Myprysm.SharedKernel/Interfaces/IWriter.cs
+++ b/src/Myprysm.SharedKernel/Interfaces/IWriter.cs
@@ -1,5 +1,7 @@
 namespace Myprysm.SharedKernel.Interfaces;
 
+using Myprysm.SharedKernel.ExecutionResults;
+
 /// <summary>
 /// <see cref="IWriter{TRequest}"/> output marker interface.
 /// </summary>
@@ -20,6 +22,6 @@ public interface IWriter<in TRequest>
     /// </summary>
     /// <param name="output">The output to write.</param>
     /// <param name="cancellation">The cancellation token.</param>
-    /// <returns>Completes when the output is written.</returns>
-    Task WriteAsync(TRequest output, CancellationToken cancellation = default);
+    /// <returns>An <see cref="IExecutionResult"/> indicating whether the operation succeeded.</returns>
+    Task<IExecutionResult> WriteAsync(TRequest output, CancellationToken cancellation = default);
 }

--- a/src/Myprysm.SharedKernel/documentation/Myprysm.SharedKernel.ExecutionResults.ExecutionResult.md
+++ b/src/Myprysm.SharedKernel/documentation/Myprysm.SharedKernel.ExecutionResults.ExecutionResult.md
@@ -42,11 +42,11 @@ Implements [IsSuccess](Myprysm.SharedKernel.ExecutionResults.IExecutionResult.md
 Returns a conflict execution result.
 
 ```csharp
-public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult Conflict();
+public static Myprysm.SharedKernel.ExecutionResults.ConflictExecutionResult Conflict();
 ```
 
 #### Returns
-[IExecutionResult](Myprysm.SharedKernel.ExecutionResults.IExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.IExecutionResult')  
+[ConflictExecutionResult](Myprysm.SharedKernel.ExecutionResults.ConflictExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.ConflictExecutionResult')  
 The conflict execution result.
 
 <a name='Myprysm.SharedKernel.ExecutionResults.ExecutionResult.Conflict(string[])'></a>
@@ -56,7 +56,7 @@ The conflict execution result.
 Returns a conflict execution result with the provided errors.
 
 ```csharp
-public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult Conflict(params string[] errors);
+public static Myprysm.SharedKernel.ExecutionResults.ConflictExecutionResult Conflict(params string[] errors);
 ```
 #### Parameters
 
@@ -67,7 +67,7 @@ public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult Conflict(pa
 The errors to report.
 
 #### Returns
-[IExecutionResult](Myprysm.SharedKernel.ExecutionResults.IExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.IExecutionResult')  
+[ConflictExecutionResult](Myprysm.SharedKernel.ExecutionResults.ConflictExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.ConflictExecutionResult')  
 A conflict execution result containing the provided errors as a reason.
 
 <a name='Myprysm.SharedKernel.ExecutionResults.ExecutionResult.Conflict(System.Collections.Generic.IEnumerable_string_)'></a>
@@ -77,7 +77,7 @@ A conflict execution result containing the provided errors as a reason.
 Returns a conflict execution result with the provided errors.
 
 ```csharp
-public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult Conflict(System.Collections.Generic.IEnumerable<string> errors);
+public static Myprysm.SharedKernel.ExecutionResults.ConflictExecutionResult Conflict(System.Collections.Generic.IEnumerable<string> errors);
 ```
 #### Parameters
 
@@ -88,7 +88,7 @@ public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult Conflict(Sy
 The errors to report.
 
 #### Returns
-[IExecutionResult](Myprysm.SharedKernel.ExecutionResults.IExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.IExecutionResult')  
+[ConflictExecutionResult](Myprysm.SharedKernel.ExecutionResults.ConflictExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.ConflictExecutionResult')  
 A conflict execution result containing the provided errors as a reason.
 
 <a name='Myprysm.SharedKernel.ExecutionResults.ExecutionResult.Failed()'></a>
@@ -98,11 +98,11 @@ A conflict execution result containing the provided errors as a reason.
 Returns a failed execution result.
 
 ```csharp
-public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult Failed();
+public static Myprysm.SharedKernel.ExecutionResults.FailedExecutionResult Failed();
 ```
 
 #### Returns
-[IExecutionResult](Myprysm.SharedKernel.ExecutionResults.IExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.IExecutionResult')  
+[FailedExecutionResult](Myprysm.SharedKernel.ExecutionResults.FailedExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.FailedExecutionResult')  
 The failed execution result.
 
 <a name='Myprysm.SharedKernel.ExecutionResults.ExecutionResult.Failed(string[])'></a>
@@ -112,7 +112,7 @@ The failed execution result.
 Returns a failed execution result with the provided errors.
 
 ```csharp
-public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult Failed(params string[] errors);
+public static Myprysm.SharedKernel.ExecutionResults.FailedExecutionResult Failed(params string[] errors);
 ```
 #### Parameters
 
@@ -123,7 +123,7 @@ public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult Failed(para
 The errors to report.
 
 #### Returns
-[IExecutionResult](Myprysm.SharedKernel.ExecutionResults.IExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.IExecutionResult')  
+[FailedExecutionResult](Myprysm.SharedKernel.ExecutionResults.FailedExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.FailedExecutionResult')  
 A failed execution result containing the provided errors as a reason.
 
 <a name='Myprysm.SharedKernel.ExecutionResults.ExecutionResult.Failed(System.Collections.Generic.IEnumerable_string_)'></a>
@@ -133,7 +133,7 @@ A failed execution result containing the provided errors as a reason.
 Returns a failed execution result with the provided errors.
 
 ```csharp
-public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult Failed(System.Collections.Generic.IEnumerable<string> errors);
+public static Myprysm.SharedKernel.ExecutionResults.FailedExecutionResult Failed(System.Collections.Generic.IEnumerable<string> errors);
 ```
 #### Parameters
 
@@ -144,7 +144,7 @@ public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult Failed(Syst
 The errors to report.
 
 #### Returns
-[IExecutionResult](Myprysm.SharedKernel.ExecutionResults.IExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.IExecutionResult')  
+[FailedExecutionResult](Myprysm.SharedKernel.ExecutionResults.FailedExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.FailedExecutionResult')  
 A failed execution result containing the provided errors as a reason.
 
 <a name='Myprysm.SharedKernel.ExecutionResults.ExecutionResult.Forbidden()'></a>
@@ -154,11 +154,11 @@ A failed execution result containing the provided errors as a reason.
 Returns a forbidden execution result.
 
 ```csharp
-public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult Forbidden();
+public static Myprysm.SharedKernel.ExecutionResults.ForbiddenExecutionResult Forbidden();
 ```
 
 #### Returns
-[IExecutionResult](Myprysm.SharedKernel.ExecutionResults.IExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.IExecutionResult')  
+[ForbiddenExecutionResult](Myprysm.SharedKernel.ExecutionResults.ForbiddenExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.ForbiddenExecutionResult')  
 The forbidden execution result.
 
 <a name='Myprysm.SharedKernel.ExecutionResults.ExecutionResult.Forbidden(string[])'></a>
@@ -168,7 +168,7 @@ The forbidden execution result.
 Returns a forbidden execution result with the provided errors.
 
 ```csharp
-public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult Forbidden(params string[] errors);
+public static Myprysm.SharedKernel.ExecutionResults.ForbiddenExecutionResult Forbidden(params string[] errors);
 ```
 #### Parameters
 
@@ -179,7 +179,7 @@ public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult Forbidden(p
 The errors to report.
 
 #### Returns
-[IExecutionResult](Myprysm.SharedKernel.ExecutionResults.IExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.IExecutionResult')  
+[ForbiddenExecutionResult](Myprysm.SharedKernel.ExecutionResults.ForbiddenExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.ForbiddenExecutionResult')  
 A forbidden execution result containing the provided errors as a reason.
 
 <a name='Myprysm.SharedKernel.ExecutionResults.ExecutionResult.Forbidden(System.Collections.Generic.IEnumerable_string_)'></a>
@@ -189,7 +189,7 @@ A forbidden execution result containing the provided errors as a reason.
 Returns a forbidden execution result with the provided errors.
 
 ```csharp
-public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult Forbidden(System.Collections.Generic.IEnumerable<string> errors);
+public static Myprysm.SharedKernel.ExecutionResults.ForbiddenExecutionResult Forbidden(System.Collections.Generic.IEnumerable<string> errors);
 ```
 #### Parameters
 
@@ -200,7 +200,7 @@ public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult Forbidden(S
 The errors to report.
 
 #### Returns
-[IExecutionResult](Myprysm.SharedKernel.ExecutionResults.IExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.IExecutionResult')  
+[ForbiddenExecutionResult](Myprysm.SharedKernel.ExecutionResults.ForbiddenExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.ForbiddenExecutionResult')  
 A forbidden execution result containing the provided errors as a reason.
 
 <a name='Myprysm.SharedKernel.ExecutionResults.ExecutionResult.NotFound()'></a>
@@ -210,11 +210,11 @@ A forbidden execution result containing the provided errors as a reason.
 Returns a not found execution result.
 
 ```csharp
-public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult NotFound();
+public static Myprysm.SharedKernel.ExecutionResults.NotFoundExecutionResult NotFound();
 ```
 
 #### Returns
-[IExecutionResult](Myprysm.SharedKernel.ExecutionResults.IExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.IExecutionResult')  
+[NotFoundExecutionResult](Myprysm.SharedKernel.ExecutionResults.NotFoundExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.NotFoundExecutionResult')  
 The not found execution result.
 
 <a name='Myprysm.SharedKernel.ExecutionResults.ExecutionResult.NotFound(string[])'></a>
@@ -224,7 +224,7 @@ The not found execution result.
 Returns a not found execution result with the provided errors.
 
 ```csharp
-public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult NotFound(params string[] errors);
+public static Myprysm.SharedKernel.ExecutionResults.NotFoundExecutionResult NotFound(params string[] errors);
 ```
 #### Parameters
 
@@ -235,7 +235,7 @@ public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult NotFound(pa
 The errors to report.
 
 #### Returns
-[IExecutionResult](Myprysm.SharedKernel.ExecutionResults.IExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.IExecutionResult')  
+[NotFoundExecutionResult](Myprysm.SharedKernel.ExecutionResults.NotFoundExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.NotFoundExecutionResult')  
 A not found execution result containing the provided errors as a reason.
 
 <a name='Myprysm.SharedKernel.ExecutionResults.ExecutionResult.NotFound(System.Collections.Generic.IEnumerable_string_)'></a>
@@ -245,7 +245,7 @@ A not found execution result containing the provided errors as a reason.
 Returns a not found execution result with the provided errors.
 
 ```csharp
-public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult NotFound(System.Collections.Generic.IEnumerable<string> errors);
+public static Myprysm.SharedKernel.ExecutionResults.NotFoundExecutionResult NotFound(System.Collections.Generic.IEnumerable<string> errors);
 ```
 #### Parameters
 
@@ -256,7 +256,7 @@ public static Myprysm.SharedKernel.ExecutionResults.IExecutionResult NotFound(Sy
 The errors to report.
 
 #### Returns
-[IExecutionResult](Myprysm.SharedKernel.ExecutionResults.IExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.IExecutionResult')  
+[NotFoundExecutionResult](Myprysm.SharedKernel.ExecutionResults.NotFoundExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.NotFoundExecutionResult')  
 A not found execution result containing the provided errors as a reason.
 
 <a name='Myprysm.SharedKernel.ExecutionResults.ExecutionResult.Success()'></a>

--- a/src/Myprysm.SharedKernel/documentation/Myprysm.SharedKernel.Interfaces.IWriter_TRequest_.md
+++ b/src/Myprysm.SharedKernel/documentation/Myprysm.SharedKernel.Interfaces.IWriter_TRequest_.md
@@ -23,7 +23,7 @@ public interface IWriter<in TRequest>
 Writes the provided output asynchronously.
 
 ```csharp
-System.Threading.Tasks.Task WriteAsync(TRequest output, System.Threading.CancellationToken cancellation=default(System.Threading.CancellationToken));
+System.Threading.Tasks.Task<Myprysm.SharedKernel.ExecutionResults.IExecutionResult> WriteAsync(TRequest output, System.Threading.CancellationToken cancellation=default(System.Threading.CancellationToken));
 ```
 #### Parameters
 
@@ -40,5 +40,5 @@ The output to write.
 The cancellation token.
 
 #### Returns
-[System.Threading.Tasks.Task](https://docs.microsoft.com/en-us/dotnet/api/System.Threading.Tasks.Task 'System.Threading.Tasks.Task')  
-Completes when the output is written.
+[System.Threading.Tasks.Task&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.Threading.Tasks.Task-1 'System.Threading.Tasks.Task`1')[IExecutionResult](Myprysm.SharedKernel.ExecutionResults.IExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.IExecutionResult')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.Threading.Tasks.Task-1 'System.Threading.Tasks.Task`1')  
+An [IExecutionResult](Myprysm.SharedKernel.ExecutionResults.IExecutionResult.md 'Myprysm.SharedKernel.ExecutionResults.IExecutionResult') indicating whether the operation succeeded.


### PR DESCRIPTION
BREAKING CHANGE: All IWriters must return an IExecutionResult to better indicate conventional errors from actual exceptions